### PR TITLE
Small typo: “Leïka” ➜ “Laïka”

### DIFF
--- a/_posts/2015-11-07-mixins-over-inheritance.md
+++ b/_posts/2015-11-07-mixins-over-inheritance.md
@@ -308,7 +308,7 @@ let amy = Human(name: "Amelia Pond", countryOfOrigin: "UK")
 class Astraunaut: Human, SpaceTraveler {}
 let neilArmstrong = Astraunaut(name: "Neil Armstrong", countryOfOrigin: "USA")
 let laika = Astraunaut(name: "Laïka", countryOfOrigin: "Russia")
-// Wait, Leïka is a Dog, right?
+// Wait, Laïka is a Dog, right?
 
 class MilleniumFalconPilot: Human, SpaceTraveler {}
 let hanSolo = MilleniumFalconPilot(name: "Han Solo")


### PR DESCRIPTION
Unless I'm missing a joke or a cultural reference or something?

Reading through the article, now :wave:
