### PR TITLE
Swift 3 Syntax for Multi-clause conditions

### DIFF
--- a/_posts/2016-03-27-pattern-matching-1.md
+++ b/_posts/2016-03-27-pattern-matching-1.md
@@ -11,6 +11,8 @@ translations:
     url: http://swift.gg/2016/04/26/pattern-matching-1/
 ---
 
+![Swift 3](https://img.shields.io/badge/Swift-3.0-green.svg)
+
 From a simple `switch` to complex expressions, pattern matching in Swift can be quite powerful. Today we're gonna start exploring it by seing some cool usages of `switch`, before going further in later articles with even more advanced pattern matching techniques.
 
 _This article serves as an introduction to the incomming articles about Pattern Matching._
@@ -25,17 +27,17 @@ The simplest and more common usage of pattern matching in Swift is via a `switch
 
 ```swift
 enum Direction {
-  case North, South, East, West
+  case north, south, east, west
 }
 
 // We can easily switch between simple enum values
 extension Direction: CustomStringConvertible {
   var description: String {
     switch self {
-    case North: return "⬆️"
-    case South: return "⬇️"
-    case East: return "➡️"
-    case West: return "⬅️"
+    case .north: return "⬆️"
+    case .south: return "⬇️"
+    case .east: return "➡️"
+    case .west: return "⬅️"
     }
   }
 }
@@ -45,38 +47,38 @@ But `switch` can go even further, allowing you to match against **patterns** con
 
 ```swift
 enum Media {
-  case Book(title: String, author: String, year: Int)
-  case Movie(title: String, director: String, year: Int)
-  case WebSite(url: NSURL, title: String)
+  case book(title: String, author: String, year: Int)
+  case movie(title: String, director: String, year: Int)
+  case website(url: NSURL, title: String)
 }
 
 extension Media {
   var mediaTitle: String {
     switch self {
-    case .Book(title: let aTitle, author: _, year: _):
+    case .book(title: let aTitle, author: _, year: _):
       return aTitle
-    case .Movie(title: let aTitle, director: _, year: _):
+    case .movie(title: let aTitle, director: _, year: _):
       return aTitle
-    case .WebSite(url: _, title: let aTitle):
+    case .website(url: _, title: let aTitle):
       return aTitle
     }
   }
 }
 
-let book = Media.Book(title: "20,000 leagues under the sea", author: "Jules Verne", year: 1870)
+let book = Media.book(title: "20,000 leagues under the sea", author: "Jules Verne", year: 1870)
 book.mediaTitle
 ```
 
-The generic syntax in this case is `case MyEnum.EnumValue(let variable)` to tell "if the value is a `MyEnum.EnumValue` — which has an associated value — then bind the variable `variable` to that associated value".
+The generic syntax in this case is `case MyEnum.enumValue(let variable)` to tell "if the value is a `MyEnum.enumValue` — which has an associated value — then bind the variable `variable` to that associated value".
 
-When the `media` instance match one of the `case` — like with `book` which is a `Media.Book` and matches the first `case` of the `switch` — then **a new variable `let aTitle` is created** and the associated value `title` is _bound_ to this given variable.
+When the `media` instance match one of the `case` — like with `book` which is a `Media.book` and matches the first `case` of the `switch` — then **a new variable `let aTitle` is created** and the associated value `title` is _bound_ to this given variable.
 That's why the `let` is needed there, because that's gonna create a new variable (well, constant) if it matches.
 
 Note that you can write the `let` in front of the whole expression, instead of using it in front of each variable, e.g. these two lines are equivalent:
 
 ```swift
-case .Book(title: let aTitle, author: let anAuthor, year: let aYear): …
-case let .Book(title: aTitle, author: anAuthor, year: aYear): …
+case .book(title: let aTitle, author: let anAuthor, year: let aYear): …
+case let .book(title: aTitle, author: anAuthor, year: aYear): …
 ```
 
 Notice also the use of the wildcard pattern `_` in the above code, which basically means "I expect to be something there, but I don't care about it, so don't bother binding it to a variable as I won't use it anyway". So that's somehow like a placeholder for a value we won't use.
@@ -90,8 +92,8 @@ Remember that `case`  is still about **pattern matching**, so it tries to **matc
 extension Media {
   var isFromJulesVerne: Bool {
     switch self {
-    case .Book(title: _, author: "Jules Verne", year: _): return true
-    case .Movie(title: _, director: "Jules Verne", year: _): return true
+    case .book(title: _, author: "Jules Verne", year: _): return true
+    case .movie(title: _, director: "Jules Verne", year: _): return true
     default: return false
     }
   }
@@ -105,10 +107,10 @@ A more useful and generic example could be something like:
 
 ```swift
 extension Media {
-  func checkAuthor(author: String) -> Bool {
+  func checkAuthor(_ author: String) -> Bool {
     switch self {
-    case .Book(title: _, author: author, year: _): return true
-    case .Movie(title: _, director: author, year: _): return true
+    case .book(title: _, author: author, year: _): return true
+    case .movie(title: _, director: author, year: _): return true
     default: return false
     }
   }
@@ -124,43 +126,43 @@ _[EDIT]_ Another great example of matching with constants have been [suggested b
 
 ```swift
 enum Response {
-  case HTTPResponse(statusCode: Int)
-  case NetworkError(NSError)
+  case httpResponse(statusCode: Int)
+  case networkError(Error)
   …
 }
 
 let response: Response = …
 switch response {
-  case .HTTPResponse(200): …
-  case .HTTPResponse(404): …
+  case .httpResponse(200): …
+  case .httpResponse(404): …
   …
 }
 
-// cleaner than using stuff like `case .HTTPResponse(let code) where code == 200`, right?
+// cleaner than using stuff like `case .httpResponse(let code) where code == 200`, right?
 ```
 {: .note }
 
 ## Binding multiple patterns at once
 
-As per Swift 2.2, we can't bind multple patterns at once. So for example this isn't possible yet, because here we try to declare variables both if `self` matches `.Book` or `.Movie` , and bind a variable in both cases:
+As per Swift 2.2, we can't bind multple patterns at once. So for example this isn't possible yet, because here we try to declare variables both if `self` matches `.book` or `.movie` , and bind a variable in both cases:
 
 ```swift
 extension Media {
   var mediaTitle2: String {
     switch self {
       // Error: 'case' labels with multiple patterns cannot declare variables
-    case let .Book(title: aTitle, author: _, year: _), let .Movie(title: aTitle, director: _, year: _):
+    case let .book(title: aTitle, author: _, year: _), let .movie(title: aTitle, director: _, year: _):
       return aTitle
-    case let .WebSite(url: _, title: aTitle):
+    case let .website(url: _, title: aTitle):
       return aTitle
     }
   }
 }
 ```
 
-This is understandable in most cases; like what would you expect the code to do if you tried to write `case let .Book(title: aTitle, author: _, year: _), let .Movie(title: _, director: _, year: aYear)`? How would you be able to use the bound variables `aTitle` or `aYear` in your `case` code then? If it's a `.Book` then only `aTitle` would have been bound, so what about `aYear`? What if you tried to use that `aYear` variable in the code of that `case`? Wouldn't probably make sense.
+This is understandable in most cases; like what would you expect the code to do if you tried to write `case let .book(title: aTitle, author: _, year: _), let .movie(title: _, director: _, year: aYear)`? How would you be able to use the bound variables `aTitle` or `aYear` in your `case` code then? If it's a `.book` then only `aTitle` would have been bound, so what about `aYear`? What if you tried to use that `aYear` variable in the code of that `case`? Wouldn't probably make sense.
 
-But one might think that in the specific case when you try to bind variables of the **same type** and with the **same name**, that would still make sense to work, like in the example above where we try to bind with `aTitle` in both cases (`.Book` and `.Movie`). And that would be quite useful to avoid repeating code, right?
+But one might think that in the specific case when you try to bind variables of the **same type** and with the **same name**, that would still make sense to work, like in the example above where we try to bind with `aTitle` in both cases (`.book` and `.movie`). And that would be quite useful to avoid repeating code, right?
 So why is this not possible in that specific case? Well fear not, [this Swift-Evolution Proposal SE-0043](https://github.com/apple/swift-evolution/blob/master/proposals/0043-declare-variables-in-case-labels-with-multiple-patterns.md) has been accepted and allow this in Swift 3.
 
 ## Using tuples without argument labels
@@ -173,9 +175,9 @@ Note that when dealing with `enum` with associated values, we can consider the a
 extension Media {
   var mediaTitle2: String {
     switch self {
-    case let .Book(title, _, _): return title
-    case let .Movie(title, _, _): return title
-    case let .WebSite(_, title): return title
+    case let .book(title, _, _): return title
+    case let .movie(title, _, _): return title
+    case let .website(_, title): return title
     }
   }
 }
@@ -187,9 +189,9 @@ extension Media {
 extension Media {
   var mediaTitle3: String {
     switch self {
-    case let .Book(tuple): return tuple.title
-    case let .Movie(tuple): return tuple.title
-    case let .WebSite(tuple): return tuple.title
+    case let .book(tuple): return tuple.title
+    case let .movie(tuple): return tuple.title
+    case let .website(tuple): return tuple.title
     }
   }
 }
@@ -198,9 +200,9 @@ extension Media {
 As an added bonus, not specifying the tuple at all is syntactic sugar for matching any associated values, so those 3 expressions are equivalent:
 
 ```swift
-case .WebSite // not specifying the tuple at all
-case .WebSite(_) // matching a single tuple of associated values that we don't care about
-case .WebSite(_, _) // matching individual associated values that we don't care about either
+case .website // not specifying the tuple at all
+case .website(_) // matching a single tuple of associated values that we don't care about
+case .website(_, _) // matching individual associated values that we don't care about either
 ```
 
 ## Using Where
@@ -211,16 +213,16 @@ Pattern matching allows way more powerful stuff than just comparing two enums. Y
 extension Media {
   var publishedAfter1930: Bool {
     switch self {
-    case let .Book(_, _, year) where year > 1930: return true
-    case let .Movie(_, _, year) where year > 1930: return true
-    case .WebSite: return true // same as "case .WebSite(_)" but we ignore the associated tuple value
+    case let .book(_, _, year) where year > 1930: return true
+    case let .movie(_, _, year) where year > 1930: return true
+    case .website: return true // same as "case .website(_)" but we ignore the associated tuple value
     default: return false
     }
   }
 }
 ```
 
-This will only match if both the left side of the pattern (like `let .Book(_, _, year)`) successfully matches, **and** the `where` condition is evaluated to `true`. This allows some powerful patterns that we'll dig into in later parts of this article series.
+This will only match if both the left side of the pattern (like `let .book(_, _, year)`) successfully matches, **and** the `where` condition is evaluated to `true`. This allows some powerful patterns that we'll dig into in later parts of this article series.
 
 ## What's next?
 

--- a/_posts/2016-03-30-pattern-matching-2.md
+++ b/_posts/2016-03-30-pattern-matching-2.md
@@ -11,6 +11,8 @@ translations:
     url: http://swift.gg/2016/04/27/pattern-matching-2/
 ---
 
+![Swift 3](https://img.shields.io/badge/Swift-3.0-green.svg)
+
 In [the previous article](/swift/pattern-matching/2016/03/27/pattern-matching-1/), we saw the basics of pattern matching using `switch` on `enums`. But what about using `switch` with anything other than `enum` types?
 
 This post is part of an article series. You can read all the parts here: [part 1](/swift/pattern-matching/2016/03/27/pattern-matching-1/), [part 2](/swift/pattern-matching/2016/03/30/pattern-matching-2/), [part 3](/swift/pattern-matching/2016/04/24/pattern-matching-3/), [part 4](/swift/pattern-matching/2016/05/16/pattern-matching-4/)
@@ -84,7 +86,7 @@ Here you see that we mixed `cases` with a single `Int` value and `cases` with `R
 Even if using `Int` for ranges is the most common case, we can also do that with other `ForwardIndexType`, including… `Character`! Remember the code above? The problem is that it printed "Consonant" even for punctuation characters and anything other than `A-Z`. So let's solve that[^only-for-demo] (and also include lowercase vowels and consonants):
 
 ```swift
-func charType(car: Character) -> String {
+func charType(_ car: Character) -> String {
   switch car {
     case "A", "E", "I", "O", "U", "Y", "a", "e", "i", "o", "u", "y":
       return "Vowel"

--- a/_posts/2016-04-24-pattern-matching-3.md
+++ b/_posts/2016-04-24-pattern-matching-3.md
@@ -11,6 +11,8 @@ translations:
     url: http://swift.gg/2016/04/28/pattern-matching-3/
 ---
 
+![Swift 3](https://img.shields.io/badge/Swift-3.0-green.svg)
+
 In parts [1](/swift/pattern-matching/2016/03/27/pattern-matching-1/) and [2](/swift/pattern-matching/2016/03/30/pattern-matching-2/) of this article series, we saw some usages of `switch` on a lot of things, including `tuples`, `Range`, `String`, `Character` and even type. But what if we can use pattern matching even with our own custom types?
 
 This post is part of an article series. You can read all the parts here: [part 1](/swift/pattern-matching/2016/03/27/pattern-matching-1/), [part 2](/swift/pattern-matching/2016/03/30/pattern-matching-2/), [part 3](/swift/pattern-matching/2016/04/24/pattern-matching-3/), [part 4](/swift/pattern-matching/2016/05/16/pattern-matching-4/)
@@ -137,9 +139,9 @@ Talking about this, I recently stumbled upon some code which used `enum` (with a
 
 ```swift
 enum MenuItem: Int {
-  case Home
-  case Account
-  case Settings
+  case home
+  case account
+  case settings
 }
 ```
 
@@ -147,26 +149,26 @@ But then to implement each tableView row based in the `MenuItem`, the code was l
 
 ```swift
 switch indexPath.row {
-case MenuItem.Home.rawValue: …
-case MenuItem.Account.rawValue: …
-case MenuItem.Settings.rawValue: …
+case MenuItem.home.rawValue: …
+case MenuItem.account.rawValue: …
+case MenuItem.settings.rawValue: …
 default: ()
 ```
 
 First of all, notice how the `switch` is done on an `Int` (`indexPath.row`) and then each `case` uses a `rawValue`. This is wrong for multiple reasons.
 
-* the first being that nothing prevents you to use any other value, like a copy/pasting could make you write `case FooBar.Baz.rawValue` and the compiler won't even complain. But you're dealing with `MenuItems`, so you should leverage the compiler to ensure you only deal with `MenuItems`, right?
+* the first being that nothing prevents you to use any other value, like a copy/pasting could make you write `case FooBar.baz.rawValue` and the compiler won't even complain. But you're dealing with `MenuItems`, so you should leverage the compiler to ensure you only deal with `MenuItems`, right?
 * the other problem is that this `switch` is not exhaustive by itself, this is why the `default` statement was necessary. I strongly recommand you to not use `default` when possible, and instead make your `switch` exhaustive, this way if you happen to add a new value to your `enum` you'll be forced to think about what to do with it instead of it being ignored or eaten up by the `default` without you realizing.
 
-So instead of switching on `indexPath` and `case ….rawValue`, you should rather build the enum from the `rawValue` first. This way you can then only switch over `cases` that use `MenuItem` enum cases, not anything else like `FooBar.Baz` or whatnot.
+So instead of switching on `indexPath` and `case ….rawValue`, you should rather build the enum from the `rawValue` first. This way you can then only switch over `cases` that use `MenuItem` enum cases, not anything else like `FooBar.baz` or whatnot.
 
 And to do that, because `MenuItem(rawValue:)` is a failable initializer and will in fact return a `MenuItem?`, you can leverage the syntactic sugar we discovered above!
 
 ```swift
 switch MenuItem(rawValue: indexPath.row) {
-case .Home?: …
-case .Account?: …
-case .Settings?: …
+case .home?: …
+case .account?: …
+case .settings?: …
 case nil: fatalError("Invalid indexPath!")
 }
 ```
@@ -177,9 +179,9 @@ Well to be honest, I rather prefer using a `guard let` for that kind of stuff, a
 ```swift
 guard let menuItem = MenuItem(rawValue: indexPath.row) else { fatalError("Invalid indexPath!") }
 switch menuItem {
-case .Home: …
-case .Account: …
-case .Settings: …
+case .home: …
+case .account: …
+case .settings: …
 }
 ```
 

--- a/_posts/2016-05-16-pattern-matching-4.md
+++ b/_posts/2016-05-16-pattern-matching-4.md
@@ -10,6 +10,8 @@ translations:
     url: http://swift.gg/2016/06/06/pattern-matching-4/
 ---
 
+![Swift 3](https://img.shields.io/badge/Swift-3.0-green.svg)
+
 Now that we've revisited the various syntaxes for pattern matching in [part 1](/swift/pattern-matching/2016/03/27/pattern-matching-1/), [part 2](/swift/pattern-matching/2016/03/30/pattern-matching-2/) and [part 3](/swift/pattern-matching/2016/04/24/pattern-matching-3/), let's finish this blog post series with some advanced syntax using `if case let`, `for case where` and all!
 
 Let's use what we saw in previous articles and apply them all to some advanced expressions.
@@ -27,29 +29,29 @@ For example, let's use an `enum` similar to the one from the previous articles:
 
 ```swift
 enum Media {
-  case Book(title: String, author: String, year: Int)
-  case Movie(title: String, director: String, year: Int)
-  case WebSite(urlString: String)
+  case book(title: String, author: String, year: Int)
+  case movie(title: String, director: String, year: Int)
+  case website(urlString: String)
 }
 ```
 
 Then we can write this[^tip]:
 
 ```swift
-let m = Media.Movie(title: "Captain America: Civil War", director: "Russo Brothers", year: 2016)
+let m = Media.movie(title: "Captain America: Civil War", director: "Russo Brothers", year: 2016)
 
-if case let Media.Movie(title, _, _) = m {
+if case let Media.movie(title, _, _) = m {
   print("This is a movie named \(title)")
 }
 ```
 
-[^tip]: The order of arguments (pattern vs. variable) in that syntax can be troubling. To remember the order, just think of it as using the same `case let Media.Movie(…)` syntax you use in a `switch`. That way, you'll remember to write `if case let Media.Movie(…) = m` instead of `if case let m = Media.Movie(…)` which wouldn't compile anyway — grouping the `case` with the **pattern** (`Media.Movie(title, _, _)`) like you do in `switch`, and not with the variable to compare it to (`m`).
+[^tip]: The order of arguments (pattern vs. variable) in that syntax can be troubling. To remember the order, just think of it as using the same `case let Media.movie(…)` syntax you use in a `switch`. That way, you'll remember to write `if case let Media.movie(…) = m` instead of `if case let m = Media.movie(…)` which wouldn't compile anyway — grouping the `case` with the **pattern** (`Media.movie(title, _, _)`) like you do in `switch`, and not with the variable to compare it to (`m`).
 
 This is equivalent to the more verbose code:
 
 ```swift
 switch m {
-  case let Media.Movie(title, _, _):
+  case let Media.movie(title, _, _):
     print("This is a movie named \(title)")
   default: () // do nothing, but this is mandatory as all switch in Swift must be exhaustive
 }
@@ -57,10 +59,10 @@ switch m {
 
 ## if case let where
 
-We can combine the `if let case` with a comma (`,`) -- where each condition is separated by `,` -- to create a multi-clause condition:
+We can combine the `if case let` with a comma (`,`) -- where each condition is separated by `,` -- to create a multi-clause condition:
 
 ```swift
-  if case let Media.Movie(_, _, year) = m, year < 1888 {
+  if case let Media.movie(_, _, year) = m, year < 1888 {
     print("Something seems wrong: the movie's year is before the first movie ever made.")
   }
 ```
@@ -73,13 +75,13 @@ Of course, `guard case let` is similar to `if case let`. You can use `guard case
 
 ```swift
 enum NetworkResponse {
-  case Response(NSURLResponse, NSData)
-  case Error(NSError)
+  case response(URLResponse, Data)
+  case error(Error)
 }
 
-func processRequestResponse(response: NetworkResponse) {
-  guard case let .Response(urlResp, data) = response,
-    let httpResp = urlResp as? NSHTTPURLResponse,
+func processRequestResponse(_ response: NetworkResponse) {
+  guard case let .response(urlResp, data) = response,
+    let httpResp = urlResp as? HTTPURLResponse,
     200..<300 ~= httpResp.statusCode else {
       print("Invalid response, can't process")
       return
@@ -95,18 +97,18 @@ Combining `for` and `case` can also let you iterate on a collection conditionall
 
 ```swift
 let mediaList: [Media] = [
-  .Book(title: "Harry Potter and the Philosopher's Stone", author: "J.K. Rowling", year: 1997),
-  .Movie(title: "Harry Potter and the Philosopher's Stone", director: "Chris Columbus", year: 2001),
-  .Book(title: "Harry Potter and the Chamber of Secrets", author: "J.K. Rowling", year: 1999),
-  .Movie(title: "Harry Potter and the Chamber of Secrets", director: "Chris Columbus", year: 2002),
-  .Book(title: "Harry Potter and the Prisoner of Azkaban", author: "J.K. Rowling", year: 1999),
-  .Movie(title: "Harry Potter and the Prisoner of Azkaban", director: "Alfonso Cuarón", year: 2004),
-  .Movie(title: "J.K. Rowling: A Year in the Life", director: "James Runcie", year: 2007),
-  .WebSite(urlString: "https://en.wikipedia.org/wiki/List_of_Harry_Potter-related_topics")
+  .book(title: "Harry Potter and the Philosopher's Stone", author: "J.K. Rowling", year: 1997),
+  .movie(title: "Harry Potter and the Philosopher's Stone", director: "Chris Columbus", year: 2001),
+  .book(title: "Harry Potter and the Chamber of Secrets", author: "J.K. Rowling", year: 1999),
+  .movie(title: "Harry Potter and the Chamber of Secrets", director: "Chris Columbus", year: 2002),
+  .book(title: "Harry Potter and the Prisoner of Azkaban", author: "J.K. Rowling", year: 1999),
+  .movie(title: "Harry Potter and the Prisoner of Azkaban", director: "Alfonso Cuarón", year: 2004),
+  .movie(title: "J.K. Rowling: A Year in the Life", director: "James Runcie", year: 2007),
+  .website(urlString: "https://en.wikipedia.org/wiki/List_of_Harry_Potter-related_topics")
 ]
 
 print("Movies only:")
-for case let Media.Movie(title, _, year) in mediaList {
+for case let Media.movie(title, _, year) in mediaList {
   print(" - \(title) (\(year))")
 }
   
@@ -125,7 +127,7 @@ Adding a `where` clause to that all can make it even more powerful:
 
 ```swift
 print("Movies by C. Columbus only:")
-for case let Media.Movie(title, director, year) in mediaList where director == "Chris Columbus" {
+for case let Media.movie(title, director, year) in mediaList where director == "Chris Columbus" {
   print(" - \(title) (\(year))")
 }
 
@@ -153,17 +155,17 @@ Let's finish this series with the Grand Finale: combine all that we learned from
 extension Media {
   var title: String? {
     switch self {
-    case let .Book(title, _, _): return title
-    case let .Movie(title, _, _): return title
+    case let .book(title, _, _): return title
+    case let .movie(title, _, _): return title
     default: return nil
     }
   }
   var kind: String {
     // Remember part 1 where we said we can omit the `(…)` associated values in the `case` if we don't care about any of them?
     switch self {
-    case .Book: return "Book"
-    case .Movie: return "Movie"
-    case .WebSite: return "Web Site"
+    case .book: return "Book"
+    case .movie: return "Movie"
+    case .website: return "Web Site"
     }
   }
 }

--- a/_posts/2016-05-16-pattern-matching-4.md
+++ b/_posts/2016-05-16-pattern-matching-4.md
@@ -57,10 +57,10 @@ switch m {
 
 ## if case let where
 
-We can combine the `if case let` with a `where` clause of course:
+We can combine the `if let case` with a comma (`,`) -- where each condition is separated by `,` -- to create a multi-clause condition:
 
 ```swift
-  if case let Media.Movie(_, _, year) = m where year < 1888 {
+  if case let Media.Movie(_, _, year) = m, year < 1888 {
     print("Something seems wrong: the movie's year is before the first movie ever made.")
   }
 ```
@@ -69,7 +69,7 @@ That can lead to quite powerful expressions that would otherwise need a complex 
 
 ## guard case let
 
-Of course, `guard case let` is similar to `if case let`. You can use `guard case let` and `guard case let … where …` to ensure something matches a pattern and a condition and exit otherwise.
+Of course, `guard case let` is similar to `if case let`. You can use `guard case let` and `guard case let … , …` to ensure something matches a pattern and a condition and exit otherwise.
 
 ```swift
 enum NetworkResponse {
@@ -79,12 +79,12 @@ enum NetworkResponse {
 
 func processRequestResponse(response: NetworkResponse) {
   guard case let .Response(urlResp, data) = response,
-    let httpResp = urlResp as? NSHTTPURLResponse
-    where 200..<300 ~= httpResp.statusCode else {
+    let httpResp = urlResp as? NSHTTPURLResponse,
+    200..<300 ~= httpResp.statusCode else {
       print("Invalid response, can't process")
       return
   }
-  print("Processing \(data.length) bytes…")
+  print("Processing \(data.count) bytes…")
   /* … */
 }
 ```


### PR DESCRIPTION
- Updated multi-clause conditions to use Swift 3 syntax
- Changed data.length to data.count for byte length example.
